### PR TITLE
Feature/healthcheck matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module "jenkins-alb" {
     timeout           = 5
     healthy_threshold = 2
     port              = 80
+    matcher           = 200,201
   }]
   vpc_id                 = "vpc-11111111111111111"
   external_load_balancer_dns_name = "test-nlb-111111111111111.elb.us-east-1.amazonaws.com"
@@ -90,7 +91,7 @@ module "jenkins-alb" {
 | service_name | Name of the service being deployed (used for DNS and Listener Rules) | string | "my-app" | no |       
 | listener_rule_port | The port on which the listener is on. | number |  80 | no |
 | listener_rule_protocol | The protocol the rule uses | string |  "HTTP" | no |                 
-| health_check | Listener Rule Health Check | list(object({ interval = number path = string timeout = number healthy_threshold = number port  = number })) | [{ interval = 60 path = "/" timeout = 5 healthy_threshold = 2 port = 80 }] | no | 
+| health_check | Listener Rule Health Check | list(object({ interval = number path = string timeout = number healthy_threshold = number port = number, matcher = number })) | [{ interval = 60 path = "/" timeout = 5 healthy_threshold = 2 port = 80 matcher = 200,201 }] | no | 
 | external_load_balancer_dns_name | Load balancer DNS name for the external DNS record | string |  "" | no |                         
 | external_load_balancer_zone_id | Load balancer zone_id for the external DNS record | string |  "" | no |
 | internal_load_balancer_dns_name | Load balancer DNS name for the internal DNS record | string |  "" | no |                         

--- a/main.tf
+++ b/main.tf
@@ -183,6 +183,7 @@ resource "aws_lb_target_group" "this" {
       healthy_threshold = lookup(health_check.value, "healthy_threshold", null)
       port              = lookup(health_check.value, "port", null)
       protocol          = lookup(health_check.value, "protocol", null)
+      matcher           = lookup(health_check.value, "matcher", null)
     }
   }
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -111,9 +111,9 @@ resource "aws_lb_listener" "http" {
     type = "fixed-response"
 
     fixed_response {
-      content_type = "${var.fixed_response_content_type}"
-      message_body = "${var.fixed_response_message_body}"
-      status_code  = "${var.fixed_response_status_code}"
+      content_type = var.fixed_response_content_type
+      message_body = var.fixed_response_message_body
+      status_code  = var.fixed_response_status_code
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -195,6 +195,7 @@ variable "health_check" {
     healthy_threshold = number
     port              = number
     protocol          = string
+    matcher           = string
   }))
   default = [{
     interval          = 60
@@ -203,6 +204,7 @@ variable "health_check" {
     healthy_threshold = 2
     port              = 80
     protocol          = "HTTP"
+    matcher           = "200"
   }]
 }
 


### PR DESCRIPTION
    Adding matcher to the health check.

    The matcher is the matcher for the status code. The current code will
    end up with a default of 200 in AWS but this should be specified for any
    health check for an ALB.

    This is useful for when services have a login page and you are checking
    the root or other similar cases.

    Updated the documentation and the code.